### PR TITLE
그룹 기능

### DIFF
--- a/src/app/groups/[id]/dashboard/_components/DashboardMenu.tsx
+++ b/src/app/groups/[id]/dashboard/_components/DashboardMenu.tsx
@@ -8,8 +8,9 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import { getGroupById } from '@/features/group/api/getGroupById';
 import { DialogTrigger } from '@radix-ui/react-dialog';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 
@@ -17,14 +18,26 @@ import { FaEdit, FaUsers, FaQuestionCircle, FaKey } from 'react-icons/fa';
 import { FaArrowRightFromBracket } from 'react-icons/fa6';
 // TODO: 그룹 수정, 초대 코드 오너만 ..
 
-export const DashboardMenu = () => {
-  const { id } = useParams();
+interface DashboardMenuProps {
+  groupId: string;
+}
+
+export const DashboardMenu = ({ groupId }: DashboardMenuProps) => {
   const router = useRouter();
+
+  const {
+    data: group,
+    isError,
+    error,
+  } = useQuery({
+    queryKey: ['groups', groupId],
+    queryFn: getGroupById,
+  });
 
   const mutation = useMutation({
     mutationFn: async () => {
       const response = await fetch(
-        `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/v1/groups/${id}/leave`,
+        `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/v1/groups/${groupId}/leave`,
         {
           method: 'delete',
           credentials: 'include',
@@ -48,26 +61,48 @@ export const DashboardMenu = () => {
     },
   });
 
+  if (isError) {
+    console.error('에러 발생:', error);
+
+    if (
+      error?.message.includes('Unauthorized') ||
+      error?.message.includes('로그인')
+    ) {
+      alert('로그인이 필요한 서비스입니다. 로그인 페이지로 이동합니다.');
+      router.replace('/login');
+    } else {
+      return <p>데이터를 불러오는 중 오류가 발생했습니다.</p>;
+    }
+  }
+
+  if (!group) {
+    return null;
+  }
+
   return (
     <div className="bg-[#F2F7FF] rounded-[14px] py-[26px] px-2">
       <ul>
-        <li className="flex items-center gap-2 hover:bg-[#e1e6ed] p-2 rounded-[5px] cursor-pointer">
-          <FaEdit className="opacity-60" />
-          <Link href={`/groups/${id}/edit`}>그룹 수정</Link>
-        </li>
+        {group.role === 'OWNER' && (
+          <li className="flex items-center gap-2 hover:bg-[#e1e6ed] p-2 rounded-[5px] cursor-pointer">
+            <FaEdit className="opacity-60" />
+            <Link href={`/groups/${groupId}/edit`}>그룹 수정</Link>
+          </li>
+        )}
         <li className="flex items-center gap-2 hover:bg-[#e1e6ed] p-2 rounded-[5px] cursor-pointer">
           <FaUsers className="opacity-60" />
-          <Link href={`/groups/${id}/members`}>멤버 보기</Link>
+          <Link href={`/groups/${groupId}/members`}>멤버 보기</Link>
         </li>
         <li className="flex items-center gap-2 hover:bg-[#e1e6ed] p-2 rounded-[5px] cursor-pointer">
           <FaQuestionCircle className="opacity-60" />
-          <Link href={`/groups/${id}/questions`}>내 질문 보기</Link>
+          <Link href={`/groups/${groupId}/questions`}>내 질문 보기</Link>
         </li>
-        <li className="flex items-center gap-2 hover:bg-[#e1e6ed] p-2 rounded-[5px] cursor-pointer">
-          <FaKey className="opacity-60" />
-          {/* TODO: 초대 코드 조회  */}
-          <Link href="#">그룹 초대 코드</Link>
-        </li>
+        {group.role === 'OWNER' && (
+          <li className="flex items-center gap-2 hover:bg-[#e1e6ed] p-2 rounded-[5px] cursor-pointer">
+            <FaKey className="opacity-60" />
+            {/* TODO: 초대 코드 조회  */}
+            <Link href="#">그룹 초대 코드</Link>
+          </li>
+        )}
         <ConfirmDialog>
           <li className="flex items-center gap-2 hover:bg-[#e1e6ed] p-2 rounded-[5px] cursor-pointer">
             <FaArrowRightFromBracket className="opacity-60" />

--- a/src/app/groups/[id]/dashboard/_components/DashboardMenu.tsx
+++ b/src/app/groups/[id]/dashboard/_components/DashboardMenu.tsx
@@ -15,6 +15,7 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 import { CopyIcon } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
 
 import { FaEdit, FaUsers, FaQuestionCircle, FaKey } from 'react-icons/fa';
 import { FaArrowRightFromBracket } from 'react-icons/fa6';
@@ -25,11 +26,7 @@ interface DashboardMenuProps {
 export const DashboardMenu = ({ groupId }: DashboardMenuProps) => {
   const router = useRouter();
 
-  const {
-    data: group,
-    isError,
-    error,
-  } = useQuery({
+  const { data: group, isError } = useQuery({
     queryKey: ['groups', groupId],
     queryFn: getGroupById,
   });
@@ -61,19 +58,12 @@ export const DashboardMenu = ({ groupId }: DashboardMenuProps) => {
     },
   });
 
-  if (isError) {
-    console.error('에러 발생:', error);
-
-    if (
-      error?.message.includes('Unauthorized') ||
-      error?.message.includes('로그인')
-    ) {
-      alert('로그인이 필요한 서비스입니다. 로그인 페이지로 이동합니다.');
-      router.replace('/login');
-    } else {
-      return <p>데이터를 불러오는 중 오류가 발생했습니다.</p>;
+  useEffect(() => {
+    if (isError) {
+      alert('해당 그룹을 찾을 수 없습니다. 프로필 페이지로 이동합니다.');
+      router.replace('/profile');
     }
-  }
+  }, [isError, router]);
 
   if (!group) {
     return null;

--- a/src/app/groups/[id]/dashboard/_components/DashboardMenu.tsx
+++ b/src/app/groups/[id]/dashboard/_components/DashboardMenu.tsx
@@ -1,16 +1,17 @@
 'use client';
+import { InviteCodeDialog } from '@/components/invite-code-dialog';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
   DialogClose,
   DialogContent,
+  DialogTrigger,
   DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
 import { getGroupById } from '@/features/group/api/getGroupById';
-import { DialogTrigger } from '@radix-ui/react-dialog';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { CopyIcon } from 'lucide-react';
 import Link from 'next/link';
@@ -109,41 +110,6 @@ export const DashboardMenu = ({ groupId }: DashboardMenuProps) => {
         )}
       </ul>
     </div>
-  );
-};
-
-const InviteCodeDialog = ({
-  inviteCode,
-  children,
-}: {
-  inviteCode: string;
-  children: React.ReactNode;
-}) => {
-  const handleCopy = () => {
-    navigator.clipboard
-      .writeText(inviteCode)
-      .then(() => alert('코드가 복사되었습니다!'));
-  };
-
-  return (
-    <Dialog>
-      <DialogTrigger asChild>{children}</DialogTrigger>
-      <DialogContent className="w-[450px] flex flex-col items-center">
-        <DialogHeader className="flex flex-col items-center">
-          <DialogTitle>앨범을 공유할 가족을 초대해보세요!</DialogTitle>
-          <DialogDescription className="text-[#8C8989]">
-            아래 코드로 멤버를 초대할 수 있어요.
-          </DialogDescription>
-        </DialogHeader>
-        <strong className="text-4xl text-[#4848F9]">{inviteCode}</strong>
-        <Button
-          onClick={handleCopy}
-          className="w-fit text-base bg-transparent hover:bg-transparent hover:opacity-80 border border-blue-100 text-black"
-        >
-          Copy link <CopyIcon className="size-4 ml-2" />
-        </Button>
-      </DialogContent>
-    </Dialog>
   );
 };
 

--- a/src/app/groups/[id]/dashboard/_components/DashboardMenu.tsx
+++ b/src/app/groups/[id]/dashboard/_components/DashboardMenu.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { Button } from '@/components/ui/button';
 import {
   Dialog,
   DialogClose,
@@ -11,13 +12,12 @@ import {
 import { getGroupById } from '@/features/group/api/getGroupById';
 import { DialogTrigger } from '@radix-ui/react-dialog';
 import { useMutation, useQuery } from '@tanstack/react-query';
+import { CopyIcon } from 'lucide-react';
 import Link from 'next/link';
-import { useParams, useRouter } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 
 import { FaEdit, FaUsers, FaQuestionCircle, FaKey } from 'react-icons/fa';
 import { FaArrowRightFromBracket } from 'react-icons/fa6';
-// TODO: 그룹 수정, 초대 코드 오너만 ..
-
 interface DashboardMenuProps {
   groupId: string;
 }
@@ -97,29 +97,67 @@ export const DashboardMenu = ({ groupId }: DashboardMenuProps) => {
           <Link href={`/groups/${groupId}/questions`}>내 질문 보기</Link>
         </li>
         {group.role === 'OWNER' && (
-          <li className="flex items-center gap-2 hover:bg-[#e1e6ed] p-2 rounded-[5px] cursor-pointer">
-            <FaKey className="opacity-60" />
-            {/* TODO: 초대 코드 조회  */}
-            <Link href="#">그룹 초대 코드</Link>
-          </li>
+          <InviteCodeDialog inviteCode={group.inviteCode}>
+            <li className="flex items-center gap-2 hover:bg-[#e1e6ed] p-2 rounded-[5px] cursor-pointer">
+              <FaKey className="opacity-60" />
+              <p>그룹 초대 코드</p>
+            </li>
+          </InviteCodeDialog>
         )}
-        <ConfirmDialog>
-          <li className="flex items-center gap-2 hover:bg-[#e1e6ed] p-2 rounded-[5px] cursor-pointer">
-            <FaArrowRightFromBracket className="opacity-60" />
-            <button
-              className="bg-none text-base"
-              onClick={() => mutation.mutate()}
-            >
-              그룹 나가기
-            </button>
-          </li>
-        </ConfirmDialog>
+        {group.role !== 'OWNER' && (
+          <RemoveDialog>
+            <li className="flex items-center gap-2 hover:bg-[#e1e6ed] p-2 rounded-[5px] cursor-pointer">
+              <FaArrowRightFromBracket className="opacity-60" />
+              <button
+                className="bg-none text-base"
+                onClick={() => mutation.mutate()}
+              >
+                그룹 나가기
+              </button>
+            </li>
+          </RemoveDialog>
+        )}
       </ul>
     </div>
   );
 };
 
-const ConfirmDialog = ({ children }: { children: React.ReactNode }) => (
+const InviteCodeDialog = ({
+  inviteCode,
+  children,
+}: {
+  inviteCode: string;
+  children: React.ReactNode;
+}) => {
+  const handleCopy = () => {
+    navigator.clipboard
+      .writeText(inviteCode)
+      .then(() => alert('코드가 복사되었습니다!'));
+  };
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>{children}</DialogTrigger>
+      <DialogContent className="w-[450px] flex flex-col items-center">
+        <DialogHeader className="flex flex-col items-center">
+          <DialogTitle>앨범을 공유할 가족을 초대해보세요!</DialogTitle>
+          <DialogDescription className="text-[#8C8989]">
+            아래 코드로 멤버를 초대할 수 있어요.
+          </DialogDescription>
+        </DialogHeader>
+        <strong className="text-4xl text-[#4848F9]">{inviteCode}</strong>
+        <Button
+          onClick={handleCopy}
+          className="w-fit text-base bg-transparent hover:bg-transparent hover:opacity-80 border border-blue-100 text-black"
+        >
+          Copy link <CopyIcon className="size-4 ml-2" />
+        </Button>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+const RemoveDialog = ({ children }: { children: React.ReactNode }) => (
   <Dialog>
     <DialogTrigger asChild>{children}</DialogTrigger>
     <DialogContent className="w-[450px]">

--- a/src/app/groups/[id]/dashboard/page.tsx
+++ b/src/app/groups/[id]/dashboard/page.tsx
@@ -1,9 +1,27 @@
+import {
+  dehydrate,
+  HydrationBoundary,
+  QueryClient,
+} from '@tanstack/react-query';
 import { DashboardMenu } from './_components/DashboardMenu';
+import { getGroupById } from '@/features/group/api/getGroupById';
 
-const Page = () => {
+const Page = async ({ params }: { params: { id: string } }) => {
+  const id = params.id;
+  const queryClient = new QueryClient();
+
+  await queryClient.prefetchQuery({
+    queryKey: ['groups', id],
+    queryFn: getGroupById,
+  });
+
+  const dehydratedState = dehydrate(queryClient);
+
   return (
     <div className="sm:m-auto w-full sm:w-[500px] px-[30px] ForGnbpaddingTop">
-      <DashboardMenu />
+      <HydrationBoundary state={dehydratedState}>
+        <DashboardMenu groupId={id} />
+      </HydrationBoundary>
     </div>
   );
 };

--- a/src/app/groups/[id]/edit/_components/edit-group.tsx
+++ b/src/app/groups/[id]/edit/_components/edit-group.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
 
@@ -14,6 +14,7 @@ import '@/components/embla/embla.css';
 import useEmblaCarousel from 'embla-carousel-react';
 import { GroupInput } from '@/app/groups/_components/group-input';
 import { getGroupById } from '@/features/group/api/getGroupById';
+import { AiOutlineLoading3Quarters } from 'react-icons/ai';
 
 type FormInputs = {
   groupName: string;
@@ -34,7 +35,11 @@ export const EditGroup = ({ id }: Props) => {
   } | null>(null);
   const imageRef = useRef<HTMLInputElement | null>(null);
 
-  const { data: group } = useQuery({
+  const {
+    data: group,
+    isLoading,
+    isError,
+  } = useQuery({
     queryKey: ['groups', id],
     queryFn: getGroupById,
     staleTime: 1000 * 60 * 5, // 5분 동안 캐싱 (선택 사항)
@@ -74,6 +79,13 @@ export const EditGroup = ({ id }: Props) => {
       alert('그룹 수정 실패했습니다. 다시 시도해주세요.');
     },
   });
+
+  useEffect(() => {
+    if (isError) {
+      alert('해당 그룹을 찾을 수 없습니다. 프로필 페이지로 이동합니다.');
+      router.replace('/profile');
+    }
+  }, [isError, router]);
 
   const { control, watch } = useForm();
 

--- a/src/app/groups/[id]/edit/_components/edit-group.tsx
+++ b/src/app/groups/[id]/edit/_components/edit-group.tsx
@@ -6,24 +6,14 @@ import { Button } from '@/components/ui/button';
 
 import { FormProvider, useForm } from 'react-hook-form';
 import { useRouter } from 'next/navigation';
-import { useMutation } from '@tanstack/react-query';
-
-import { FaArrowLeft } from 'react-icons/fa6';
+import { useMutation, useQuery } from '@tanstack/react-query';
 
 import '@/app/signup/verifyInputStyle.css';
 
 import '@/components/embla/embla.css';
-import {
-  DotButton,
-  useDotButton,
-} from '@/components/embla/EmblaCarouselDotButton';
-import {
-  PrevButton,
-  usePrevNextButtons,
-} from '@/components/embla/EmblaCarouselButtons';
 import useEmblaCarousel from 'embla-carousel-react';
-import LoginHeader from '@/components/LoginHeader';
 import { GroupInput } from '@/app/groups/_components/group-input';
+import { getGroupById } from '@/features/group/api/getGroupById';
 
 type FormInputs = {
   groupName: string;
@@ -38,7 +28,17 @@ type Props = {
 export const EditGroup = ({ id }: Props) => {
   const router = useRouter();
   const [emblaRef, emblaApi] = useEmblaCarousel({ watchDrag: false });
-  //TODO: query group 상세 조회 불러오기
+  const [preview, setPreview] = useState<{
+    dataUrl: string;
+    file: File;
+  } | null>(null);
+  const imageRef = useRef<HTMLInputElement | null>(null);
+
+  const { data: group } = useQuery({
+    queryKey: ['groups', id],
+    queryFn: getGroupById,
+    staleTime: 1000 * 60 * 5, // 5분 동안 캐싱 (선택 사항)
+  });
 
   const mutation = useMutation({
     mutationFn: async () => {
@@ -75,18 +75,12 @@ export const EditGroup = ({ id }: Props) => {
     },
   });
 
-  const [preview, setPreview] = useState<{
-    dataUrl: string;
-    file: File;
-  } | null>(null);
-  const imageRef = useRef<HTMLInputElement | null>(null);
-
   const { control, watch } = useForm();
 
   const form = useForm<FormInputs>({
     defaultValues: {
-      groupName: '',
-      groupDescription: '',
+      groupName: group?.name,
+      groupDescription: group?.groupDescription,
     },
   });
 
@@ -119,7 +113,7 @@ export const EditGroup = ({ id }: Props) => {
   return (
     <main>
       <article className="max-w-md mx-auto">
-        <section ref={emblaRef} className="overflow-hidden h-full">
+        <section ref={emblaRef} className="overflow-hidden h-full mb-[80px]">
           <FormProvider {...form}>
             <form
               className="flex h-full"
@@ -154,14 +148,18 @@ export const EditGroup = ({ id }: Props) => {
                   name="groupName"
                   label="그룹 이름"
                   control={control}
-                  placeholder="그룹 이름을 입력해주세요"
+                  placeholder={group?.name || '우리 가족 앨범'}
+                  defaultValue={group?.name}
                   errorMessage="그룹 이름을 입력해주세요."
                 />
                 <GroupInput
                   name="groupDescription"
                   label="그룹 설명"
                   control={control}
-                  placeholder="예) 가족 앨범, 자녀 앨범"
+                  placeholder={
+                    group?.groupDescription || '예) 가족 테마, 우정 테마'
+                  }
+                  defaultValue={group?.groupDescription}
                   errorMessage="그룹에 대한 설명을 입력해주세요."
                 />
                 {mutation.isPending ? (

--- a/src/app/groups/[id]/edit/_components/edit-group.tsx
+++ b/src/app/groups/[id]/edit/_components/edit-group.tsx
@@ -87,14 +87,23 @@ export const EditGroup = ({ id }: Props) => {
     }
   }, [isError, router]);
 
-  const { control, watch } = useForm();
+  const { control, watch, reset } = useForm();
 
   const form = useForm<FormInputs>({
     defaultValues: {
-      groupName: group?.name,
-      groupDescription: group?.groupDescription,
+      groupName: '',
+      groupDescription: '',
     },
   });
+
+  useEffect(() => {
+    if (group) {
+      reset({
+        groupName: group.name || '',
+        groupDescription: group.groupDescription || '',
+      });
+    }
+  }, [group, reset]);
 
   const groupNameValue = watch('groupName');
   const groupDescriptionValue = watch('groupDescription');
@@ -118,6 +127,7 @@ export const EditGroup = ({ id }: Props) => {
     }
   };
 
+  console.log(groupNameValue, groupDescriptionValue);
   const onSubmit = () => {
     mutation.mutate();
   };

--- a/src/app/groups/[id]/edit/page.tsx
+++ b/src/app/groups/[id]/edit/page.tsx
@@ -1,10 +1,4 @@
-import {
-  dehydrate,
-  HydrationBoundary,
-  QueryClient,
-} from '@tanstack/react-query';
 import { EditGroup } from './_components/edit-group';
-import { getSingleGroup } from '@/features/group/api/getSingleGroup';
 
 type Props = {
   params: { id: string };
@@ -12,18 +6,7 @@ type Props = {
 const Page = async ({ params }: Props) => {
   const { id } = params;
 
-  // const queryClient = new QueryClient();
-  // await queryClient.prefetchQuery({
-  //   queryKey: ['groups', id],
-  //   queryFn: getSingleGroup,
-  // });
-  // const dehydratedState = dehydrate(queryClient);
-
-  return (
-    // <HydrationBoundary state={dehydratedState}>
-    <EditGroup id={id} />
-    // </HydrationBoundary>
-  );
+  return <EditGroup id={id} />;
 };
 
 export default Page;

--- a/src/app/groups/[id]/members/_components/group-info.tsx
+++ b/src/app/groups/[id]/members/_components/group-info.tsx
@@ -4,15 +4,29 @@ import Image from 'next/image';
 import { AiOutlineLoading3Quarters } from 'react-icons/ai';
 
 import { getGroupById } from '@/features/group/api/getGroupById';
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
 interface GroupInfoProps {
   id: string;
 }
 
 export const GroupInfo = ({ id }: GroupInfoProps) => {
-  const { data: group, isLoading } = useQuery({
+  const router = useRouter();
+  const {
+    data: group,
+    isLoading,
+    isError,
+  } = useQuery({
     queryKey: ['groups', id],
     queryFn: getGroupById,
   });
+
+  useEffect(() => {
+    if (isError) {
+      alert('해당 그룹을 찾을 수 없습니다. 프로필 페이지로 이동합니다.');
+      router.replace('/profile');
+    }
+  }, [isError, router]);
 
   if (isLoading) {
     return (

--- a/src/app/groups/[id]/members/_components/group-info.tsx
+++ b/src/app/groups/[id]/members/_components/group-info.tsx
@@ -1,14 +1,36 @@
+'use client';
+import { useQuery } from '@tanstack/react-query';
 import Image from 'next/image';
+import { AiOutlineLoading3Quarters } from 'react-icons/ai';
 
-export const GroupInfo = () => {
+import { getGroupById } from '@/features/group/api/getGroupById';
+interface GroupInfoProps {
+  id: string;
+}
+
+export const GroupInfo = ({ id }: GroupInfoProps) => {
+  const { data: group, isLoading } = useQuery({
+    queryKey: ['groups', id],
+    queryFn: getGroupById,
+  });
+
+  if (isLoading) {
+    return (
+      <p className="w-full h-[200px] text-[#c6c7cb] flex items-center justify-center text-center">
+        <AiOutlineLoading3Quarters className="size-8 animate-spin" />
+      </p>
+    );
+  }
+
   return (
     <div>
-      <div className="flex items-center mb-4">
+      <div className="flex items-center mb-2">
         <div className="relative mr-[15px] size-[68px] rounded-full overflow-hidden">
-          <Image src="/images/4.png" alt="그룹 이미지" fill />
+          <Image src={group?.groupImageUrl} alt="그룹 이미지" fill />
         </div>
-        <strong className="flex-grow text-xl">미니언즈 모임</strong>
+        <strong className="flex-grow text-xl">{group?.name}</strong>
       </div>
+      <p className="text-xs text-gray-400">{group?.groupDescription}</p>
     </div>
   );
 };

--- a/src/app/groups/[id]/members/_components/member-action-dropdown.tsx
+++ b/src/app/groups/[id]/members/_components/member-action-dropdown.tsx
@@ -10,26 +10,19 @@ import {
   DropdownMenuShortcut,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@/components/ui/dialog';
 
-import { FaUserMinus, FaUserPlus, FaUsersCog } from 'react-icons/fa';
+import { FaUserMinus, FaUserPlus } from 'react-icons/fa';
 import { useRouter } from 'next/navigation';
 import { PiPencilDuotone } from 'react-icons/pi';
-import { Dispatch, SetStateAction, useState } from 'react';
-import { InviteMember } from './invite-member';
+import { Dispatch, SetStateAction } from 'react';
+import { InviteCodeDialog } from '@/components/invite-code-dialog';
 
 type Props = {
   setIsActive: Dispatch<SetStateAction<boolean>>;
+  inviteCode: string;
 };
 
-export const MemberActionDropdown = ({ setIsActive }: Props) => {
+export const MemberActionDropdown = ({ setIsActive, inviteCode }: Props) => {
   const router = useRouter();
 
   const handleSelectMember = () => {
@@ -57,7 +50,7 @@ export const MemberActionDropdown = ({ setIsActive }: Props) => {
                 <FaUserMinus />
               </DropdownMenuShortcut>
             </DropdownMenuItem>
-            <InviteMember>
+            <InviteCodeDialog inviteCode={inviteCode}>
               <DropdownMenuItem
                 className="hover:bg-[#e5e7eb] cursor-pointer"
                 onSelect={(e) => e.preventDefault()}
@@ -67,7 +60,7 @@ export const MemberActionDropdown = ({ setIsActive }: Props) => {
                   <FaUserPlus />
                 </DropdownMenuShortcut>
               </DropdownMenuItem>
-            </InviteMember>
+            </InviteCodeDialog>
           </DropdownMenuGroup>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/src/app/groups/[id]/members/_components/member-list.tsx
+++ b/src/app/groups/[id]/members/_components/member-list.tsx
@@ -22,7 +22,7 @@ type MemberProps = {
 export const MemberList = ({ id }: MemberListProps) => {
   const [isActive, setIsActive] = useState(false);
 
-  const { data: members, isLoading } = useQuery({
+  const { data: members, isLoading: memberLoading } = useQuery({
     queryKey: ['groups', id, 'members'],
     queryFn: getMembersByGroupId,
   });
@@ -39,10 +39,13 @@ export const MemberList = ({ id }: MemberListProps) => {
           멤버 목록 ({members?.length})
         </div>
         {group?.role === 'OWNER' && (
-          <MemberActionDropdown setIsActive={setIsActive} />
+          <MemberActionDropdown
+            setIsActive={setIsActive}
+            inviteCode={group?.inviteCode}
+          />
         )}
       </div>
-      {isLoading && (
+      {memberLoading && (
         <p className="w-full h-[200px] text-[#c6c7cb] flex items-center justify-center text-center">
           <AiOutlineLoading3Quarters className="size-8 animate-spin" />
         </p>

--- a/src/app/groups/[id]/members/_components/member-list.tsx
+++ b/src/app/groups/[id]/members/_components/member-list.tsx
@@ -6,6 +6,7 @@ import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { getMembersByGroupId } from '@/features/member/api/getMembersByGroupId';
 import { AiOutlineLoading3Quarters } from 'react-icons/ai';
+import { getGroupById } from '@/features/group/api/getGroupById';
 
 interface MemberListProps {
   id: string;
@@ -26,14 +27,20 @@ export const MemberList = ({ id }: MemberListProps) => {
     queryFn: getMembersByGroupId,
   });
 
-  console.log(members);
+  const { data: group } = useQuery({
+    queryKey: ['groups', id],
+    queryFn: getGroupById,
+  });
+
   return (
     <div className="mt-10 pb-[102px]">
       <div className="flex justify-between mb-[17px]">
         <div className="text-[13px] font-semibold border border-t-0 border-x-0 border-b-2 border-b-[#4848F9]">
-          멤버 목록
+          멤버 목록 ({members?.length})
         </div>
-        <MemberActionDropdown setIsActive={setIsActive} />
+        {group?.role === 'OWNER' && (
+          <MemberActionDropdown setIsActive={setIsActive} />
+        )}
       </div>
       {isLoading && (
         <p className="w-full h-[200px] text-[#c6c7cb] flex items-center justify-center text-center">
@@ -46,6 +53,7 @@ export const MemberList = ({ id }: MemberListProps) => {
             <MemberItem
               key={member.id}
               groupId={id}
+              groupOwnerId={group.ownerUserId}
               memberId={member.id}
               isActive={isActive}
               setIsActive={setIsActive}
@@ -63,6 +71,7 @@ type MemberItemProps = {
   isActive: boolean;
   setIsActive: React.Dispatch<React.SetStateAction<boolean>>;
   groupId: string;
+  groupOwnerId: string;
   memberId: string;
   imageUrl: string;
   memberName: string;
@@ -72,14 +81,16 @@ const MemberItem = ({
   isActive,
   setIsActive,
   groupId,
+  groupOwnerId,
   memberId,
   imageUrl,
   memberName,
 }: MemberItemProps) => {
-  // TODO: 그룹 오너일 때만 삭제할 수 있게
+  const isOwner = groupOwnerId === memberId;
+
   return (
     <div className="relative">
-      {isActive && (
+      {isActive && !isOwner && (
         <AlertKickoutMember
           setIsActive={setIsActive}
           groupId={groupId}

--- a/src/app/groups/[id]/members/page.tsx
+++ b/src/app/groups/[id]/members/page.tsx
@@ -1,29 +1,13 @@
 import { MemberList } from './_components/member-list';
 import { GroupInfo } from './_components/group-info';
-import {
-  dehydrate,
-  HydrationBoundary,
-  QueryClient,
-} from '@tanstack/react-query';
-import { getMembersByGroupId } from '@/features/member/api/getMembersByGroupId';
 
 const Page = async ({ params }: { params: { id: string } }) => {
-  const queryClient = new QueryClient();
   const id = params.id;
-
-  await queryClient.prefetchQuery({
-    queryKey: ['groups', id, 'members'],
-    queryFn: getMembersByGroupId,
-  });
-
-  const dehydratedState = dehydrate(queryClient);
 
   return (
     <div className="px-[30px] m-auto w-full sm:w-[500px] h-screen ForGnbpaddingTop">
-      <HydrationBoundary state={dehydratedState}>
-        <GroupInfo />
-        <MemberList id={id} />
-      </HydrationBoundary>
+      <GroupInfo id={id} />
+      <MemberList id={id} />
     </div>
   );
 };

--- a/src/app/groups/_components/group-input.tsx
+++ b/src/app/groups/_components/group-input.tsx
@@ -12,6 +12,7 @@ interface GroupInputProps {
   name: string;
   label: string;
   control: Control<FieldArray | any>;
+  defaultValue?: string;
   errorMessage?: string;
   placeholder?: string;
 }
@@ -21,13 +22,14 @@ export const GroupInput = ({
   control,
   errorMessage,
   placeholder,
+  defaultValue,
 }: GroupInputProps) => {
   const [focus, setFocus] = useState(false);
 
   const groupInputWatched = useWatch({
     control,
     name,
-    defaultValue: '',
+    defaultValue: defaultValue || '',
   });
 
   return (
@@ -42,6 +44,7 @@ export const GroupInput = ({
               onFocus={() => setFocus(true)}
               className="w-full border-b-[1px] border-b-[#5F5F5F] leading-9 placeholder:text-[#C2C2C2] focus:outline-none main-bg"
               placeholder={placeholder}
+              defaultValue={defaultValue}
               {...control.register(name)}
             />
           </FormControl>

--- a/src/app/groups/join/page.tsx
+++ b/src/app/groups/join/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import Link from 'next/link';
 import { FaArrowLeft } from 'react-icons/fa6';
 import { Button } from '@/components/ui/button';
 
@@ -56,56 +55,52 @@ const join = () => {
   };
 
   return (
-    <main>
-      <article className="max-w-md mx-auto w-fit mt-[281px]">
-        <div>
+    <div className="m-auto w-full sm:w-[500px] h-screen ForGnbpaddingTop">
+      <div className="h-full flex flex-col justify-between pb-[90px] sm:justify-around">
+        {/* 그룹참여 단계 */}
+        <div className="p-4 flex flex-col items-center">
           <div>
-            {/* 그룹참여 단계 */}
-            <div className="min-w-full p-4 flex flex-col items-center mb-[229px]">
-              <div className="">
-                <h2 className="text-[30px] font-bold mb-[6px] text-center">
-                  그룹에 참여하기
-                </h2>
-                <p className="font-medium text-[16px] text-[#858585] text-center mb-[34px]">
-                  아래에 코드를 입력해주세요
-                </p>
-                <VerificationInput
-                  onComplete={handleComplete}
-                  classNames={{
-                    container: 'container',
-                    character: 'character',
-                    characterInactive: 'character--inactive',
-                    characterSelected: 'character--selected',
-                    characterFilled: 'character--filled',
-                  }}
-                />
-              </div>
-            </div>
-            <div className="flex justify-center">
-              <Button
-                disabled={joinCode === null || joinCode!.length !== 6}
-                onClick={() =>
-                  mutation.mutate({
-                    inviteCode: joinCode as string,
-                    groupNickname: '',
-                  })
-                }
-              >
-                시작하기
-              </Button>
-            </div>
-          </div>
-          <div className="fixed top-[54px] left-[27px]">
-            <button
-              className="w-[34px] h-[34px] text-[34px]"
-              onClick={() => router.replace('/profile')}
-            >
-              <FaArrowLeft className="w-[34px] h-[34px]" />
-            </button>
+            <h2 className="text-[30px] font-bold mb-[6px] text-center">
+              그룹에 참여하기
+            </h2>
+            <p className="font-medium text-[16px] text-[#858585] text-center mb-[34px]">
+              아래에 코드를 입력해주세요
+            </p>
+            <VerificationInput
+              onComplete={handleComplete}
+              classNames={{
+                container: 'container',
+                character: 'character',
+                characterInactive: 'character--inactive',
+                characterSelected: 'character--selected',
+                characterFilled: 'character--filled',
+              }}
+            />
           </div>
         </div>
-      </article>
-    </main>
+        <div className="flex justify-center">
+          <Button
+            disabled={joinCode === null || joinCode!.length !== 6}
+            onClick={() =>
+              mutation.mutate({
+                inviteCode: joinCode as string,
+                groupNickname: '',
+              })
+            }
+          >
+            시작하기
+          </Button>
+        </div>
+      </div>
+      <div className="fixed top-[54px] left-[27px]">
+        <button
+          className="w-[34px] h-[34px] text-[34px]"
+          onClick={() => router.replace('/profile')}
+        >
+          <FaArrowLeft className="w-[34px] h-[34px]" />
+        </button>
+      </div>
+    </div>
   );
 };
 

--- a/src/app/groups/join/page.tsx
+++ b/src/app/groups/join/page.tsx
@@ -13,6 +13,7 @@ import { useState } from 'react';
 const join = () => {
   const router = useRouter();
   const [joinCode, setJoinCode] = useState<string | null>(null);
+  // TODO: groupNickname 필드 삭제
   const mutation = useMutation({
     mutationFn: async ({
       inviteCode,
@@ -54,7 +55,6 @@ const join = () => {
     setJoinCode(value);
   };
 
-  // TODO: 그룹 관계 보류
   return (
     <main>
       <article className="max-w-md mx-auto w-fit mt-[281px]">
@@ -87,7 +87,7 @@ const join = () => {
                 onClick={() =>
                   mutation.mutate({
                     inviteCode: joinCode as string,
-                    groupNickname: '딸',
+                    groupNickname: '',
                   })
                 }
               >

--- a/src/app/profile/_components/user-groups.tsx
+++ b/src/app/profile/_components/user-groups.tsx
@@ -43,11 +43,11 @@ export const UserGroups = () => {
         <div className="grid grid-cols-2 gap-3 items-start justify-items-center">
           {groups.map((group: GroupInfoProps) => (
             <div
-              className="w-full overflow-hidden"
+              className="w-full overflow-hidden cursor-pointer hover:opacity-80"
               key={group.id}
               onClick={() => router.push(`/groups/${group.id}/dashboard`)}
             >
-              <div className="relative mb-3 size-[150px] rounded-[14px] overflow-hidden cursor-pointer hover:opacity-90">
+              <div className="relative mb-3 size-[150px] rounded-[14px] overflow-hidden">
                 <Image
                   src={group.groupImageUrl}
                   alt="그룹 이미지"

--- a/src/app/profile/_components/user-groups.tsx
+++ b/src/app/profile/_components/user-groups.tsx
@@ -14,7 +14,9 @@ type GroupInfoProps = {
   name: string;
   groupImageUrl: string;
   description: string;
+  ownerName: string;
 };
+
 export const UserGroups = () => {
   const router = useRouter();
 
@@ -61,7 +63,7 @@ export const UserGroups = () => {
               <p className="mb-[7px] text-xs w-[120px] h-fit max-h-[32px] overflow-hidden line-clamp-2">
                 {group.description}
               </p>
-              <p className="text-[10px] text-[#555555]">@그룹장이름</p>
+              <p className="text-[10px] text-[#555555]">@{group.ownerName}</p>
             </div>
           ))}
         </div>

--- a/src/app/profile/_components/user-info.tsx
+++ b/src/app/profile/_components/user-info.tsx
@@ -1,8 +1,8 @@
 'use client';
 import { useQuery } from '@tanstack/react-query';
-import { useRouter } from 'next/navigation';
-import Image from 'next/image';
+import { AiOutlineLoading3Quarters } from 'react-icons/ai';
 
+import Image from 'next/image';
 import { Button } from '@/components/ui/button';
 
 import { getUser } from '@/features/auth/api/getUser';
@@ -14,22 +14,20 @@ type UserType = {
 };
 
 export const UserInfo = () => {
-  const router = useRouter();
-  const { data, error } = useQuery({
+  const { data, isLoading } = useQuery({
     queryKey: ['user'],
     queryFn: getUser,
   });
 
-  if (error) {
-    alert('로그인이 필요한 서비스입니다. 로그인 페이지로 이동합니다.');
-    router.replace('/login');
+  if (isLoading) {
+    return (
+      <p className="w-full h-[200px] text-[#c6c7cb] flex items-center justify-center text-center">
+        <AiOutlineLoading3Quarters className="size-8 animate-spin" />
+      </p>
+    );
   }
 
-  if (!data) {
-    return null;
-  }
-
-  const user: UserType = data.user;
+  const user: UserType = data?.user;
 
   return (
     <div>

--- a/src/app/profile/_components/user-info.tsx
+++ b/src/app/profile/_components/user-info.tsx
@@ -1,16 +1,45 @@
-import { Button } from '@/components/ui/button';
+'use client';
+import { useQuery } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 
+import { Button } from '@/components/ui/button';
+
+import { getUser } from '@/features/auth/api/getUser';
+
+type UserType = {
+  name: string;
+  profileImgUrl: string;
+  email: string;
+};
+
 export const UserInfo = () => {
+  const router = useRouter();
+  const { data, error } = useQuery({
+    queryKey: ['user'],
+    queryFn: getUser,
+  });
+
+  if (error) {
+    alert('로그인이 필요한 서비스입니다. 로그인 페이지로 이동합니다.');
+    router.replace('/login');
+  }
+
+  if (!data) {
+    return null;
+  }
+
+  const user: UserType = data.user;
+
   return (
     <div>
       <div className="flex items-center mb-4">
         <div className="relative mr-[15px] size-[68px] rounded-full overflow-hidden">
-          <Image src="/images/4.png" alt="유저 이미지" fill />
+          <Image src={user?.profileImgUrl} alt="유저 이미지" fill />
         </div>
-        <strong className="flex-grow text-xl">이름</strong>
+        <strong className="flex-grow text-xl">{user?.name}</strong>
       </div>
-      <p className="mb-4 text-xs">너 지져서 나오면 10원에 100대야.</p>
+      <p className="mb-4 text-xs">-</p>
       <Button className="w-full h-7 text-xs rounded-[6px]">프로필 수정</Button>
     </div>
   );

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,34 +1,11 @@
-import {
-  dehydrate,
-  HydrationBoundary,
-  QueryClient,
-} from '@tanstack/react-query';
 import { UserGroups } from './_components/user-groups';
 import { UserInfo } from './_components/user-info';
-import { getUserGroups } from '@/features/group/api/getUserGroups';
-import { getUser } from '@/features/auth/api/getUser';
 
 const Page = async () => {
-  const queryClient = new QueryClient();
-
-  await queryClient.prefetchQuery({
-    queryKey: ['user', 'groups'],
-    queryFn: getUserGroups,
-  });
-
-  await queryClient.prefetchQuery({
-    queryKey: ['user'],
-    queryFn: getUser,
-  });
-
-  const dehydratedState = dehydrate(queryClient);
-
   return (
     <div className="px-[30px] m-auto w-full sm:w-[500px] h-screen ForGnbpaddingTop">
-      <HydrationBoundary state={dehydratedState}>
-        <UserInfo />
-        <UserGroups />
-      </HydrationBoundary>
+      <UserInfo />
+      <UserGroups />
     </div>
   );
 };

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -6,6 +6,7 @@ import {
 import { UserGroups } from './_components/user-groups';
 import { UserInfo } from './_components/user-info';
 import { getUserGroups } from '@/features/group/api/getUserGroups';
+import { getUser } from '@/features/auth/api/getUser';
 
 const Page = async () => {
   const queryClient = new QueryClient();
@@ -13,6 +14,11 @@ const Page = async () => {
   await queryClient.prefetchQuery({
     queryKey: ['user', 'groups'],
     queryFn: getUserGroups,
+  });
+
+  await queryClient.prefetchQuery({
+    queryKey: ['user'],
+    queryFn: getUser,
   });
 
   const dehydratedState = dehydrate(queryClient);

--- a/src/components/invite-code-dialog.tsx
+++ b/src/components/invite-code-dialog.tsx
@@ -1,0 +1,45 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { Button } from './ui/button';
+import { CopyIcon } from 'lucide-react';
+
+export const InviteCodeDialog = ({
+  inviteCode,
+  children,
+}: {
+  inviteCode: string;
+  children: React.ReactNode;
+}) => {
+  const handleCopy = () => {
+    navigator.clipboard
+      .writeText(inviteCode)
+      .then(() => alert('코드가 복사되었습니다!'));
+  };
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>{children}</DialogTrigger>
+      <DialogContent className="w-[450px] flex flex-col items-center">
+        <DialogHeader className="flex flex-col items-center">
+          <DialogTitle>앨범을 공유할 가족을 초대해보세요!</DialogTitle>
+          <DialogDescription className="text-[#8C8989]">
+            아래 코드로 멤버를 초대할 수 있어요.
+          </DialogDescription>
+        </DialogHeader>
+        <strong className="text-4xl text-[#4848F9]">{inviteCode}</strong>
+        <Button
+          onClick={handleCopy}
+          className="w-fit text-base bg-transparent hover:bg-transparent hover:opacity-80 border border-blue-100 text-black"
+        >
+          Copy link <CopyIcon className="size-4 ml-2" />
+        </Button>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/features/auth/api/getUser.ts
+++ b/src/features/auth/api/getUser.ts
@@ -1,6 +1,6 @@
 export async function getUser() {
   const response = await fetch(
-    `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/v1/mock/users/me`,
+    `${process.env.NEXT_PUBLIC_API_BASE_URL}/user/my-page`,
     {
       next: {
         tags: ['user'],
@@ -10,7 +10,6 @@ export async function getUser() {
   );
 
   if (!response.ok) {
-    console.error('Error:', response.status, response.statusText);
     const errorData = await response.json();
     console.error('Error details:', errorData);
     throw new Error('Failed to fetch user data');

--- a/src/features/group/api/getGroupById.ts
+++ b/src/features/group/api/getGroupById.ts
@@ -1,4 +1,4 @@
-export async function getSingleGroup({
+export async function getGroupById({
   queryKey,
 }: {
   queryKey: [string, string];
@@ -8,7 +8,7 @@ export async function getSingleGroup({
     `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/v1/groups/${id}`,
     {
       next: {
-        tags: ['user', 'groups'],
+        tags: ['groups', id],
       },
       credentials: 'include',
     },

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export function middleware(req: NextRequest) {
+  const token = req.cookies.get('jwtToken');
+
+  // 보호된 페이지에 접근하려고 하는데 세션 토큰이 없으면 로그인 페이지로 이동
+  if (!token) {
+    return NextResponse.redirect(new URL('/login', req.url));
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: [
+    '/profile',
+    '/albums/:path*',
+    '/groups/:path*',
+    '/answers/:path*',
+    '/likes/:path*',
+    '/home',
+    '/uploads/:path*',
+  ], // ✅ 보호할 경로 패턴 지정
+};


### PR DESCRIPTION
## 유저 프로필 
- 유저 데이터 조회 api 연동

## 그룹 수정 페이지
- 그룹 이름, 그룹 설명에 기존 데이터 채움
**🐛 수정사항: 그룹 수정 시 기존 데이터가 반영되지 않아 버튼이 계속 비활성화되는 문제 해결
- `useForm`의 `defaultValues`가 `watch()`에서 반영되지 않아 `useEffect`를 활용해 `reset()`을 실행하도록 수정
- 그룹 데이터가 변경될 때 `reset()`을 통해 `groupName`과 `groupDescription` 값이 반영되도록 처리
```javascript
const { control, watch, reset } = useForm();

  const form = useForm<FormInputs>({
    defaultValues: {
      groupName: '',
      groupDescription: '',
    },
  });

  useEffect(() => {
    if (group) {
      reset({
        groupName: group.name || '',
        groupDescription: group.groupDescription || '',
      });
    }
  }, [group, reset]);

return (
...
<Button
    type="submit"
    disabled={
      preview === null ||
      groupNameValue.length === 0 ||
      groupDescriptionValue.length === 0
    }
  >
    수정하기
  </Button>
)
```

## 그룹 멤버 조회 페이지
- dropdown menu에 멤버 초대(초대 코드 조회), 멤버 삭제 메뉴가 있는데 그룹 오너는 자기 자신 삭제 못함
- 그룹 오너가 아닌 경우 dropdown menu 숨김 처리

## 초대 코드 조회 공통 컴포넌트로 분리
- /groups/id/dashboard, /groups/id/members의 초대 코드 조회 부분에 쓰임

## `useQuery`로 데이터 조회 시 `isLoading` 옵션을 이용해 데이터 가져올 때까지 loading 애니메이션 처리

## 로그인 안 한 유저는 로그인 페이지로 이동 - middleware.ts 이용
jwtToken을 이용해 사용자 로그인 여부를 확인, token이 없다면 로그인 페이지로 이동

##  Improve: 그룹이 없는 사용자가 직접 URL 입력 시 리디렉트 처리
- 사용자가 그룹을 생성하지 않았음에도 직접 `/groups/:id/..` 경로로 접근하는 경우를 처리
- `useQuery`에서 그룹 데이터를 가져오지 못하면 `isError` 상태가 발생하도록 설정
- `useEffect`를 활용하여 `isError` 상태일 때 `alert`을 띄우고 `/profile` 페이지로 자동 리디렉트