### PR TITLE
feat: 앨범 선택 페이지 추가

### DIFF
--- a/src/app/groups/[id]/albums/select/_components/album-list.tsx
+++ b/src/app/groups/[id]/albums/select/_components/album-list.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { AiOutlineLoading3Quarters, AiOutlineCamera } from 'react-icons/ai';
+import { HiOutlinePlus } from 'react-icons/hi';
+
+import { getAlbumsByGroupId } from '@/features/album/api/getAlbumsByGroupId';
+import { useRouter } from 'next/navigation';
+
+interface Props {
+  groupId: string;
+}
+
+interface AlbumType {
+  id: string;
+  description: string;
+  title: string;
+  createdAt: string;
+  updatedAt: string;
+  recentMedia: RecentMediaType[];
+}
+
+interface RecentMediaType {
+  id: string;
+  fileUrl: string;
+  thumbnailUrl: string;
+}
+
+export const AlbumList = ({ groupId }: Props) => {
+  const router = useRouter();
+
+  const { data: albums, isLoading } = useQuery({
+    queryKey: ['groupAlbums', groupId],
+    queryFn: getAlbumsByGroupId,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="w-full h-[400px] flex items-center justify-center">
+        <AiOutlineLoading3Quarters className="size-8 animate-spin text-gray-400" />
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <h2 className="mb-6 text-center text-xl font-medium text-gray-700">
+        질문할 앨범을 선택해주세요
+      </h2>
+
+      <div className="grid grid-cols-2">
+        {albums.map((album: AlbumType) => (
+          <div
+            key={album.id}
+            className="mx-[30px] mb-2 group relative cursor-pointer transition-transform hover:scale-105"
+            onClick={() => {
+              router.push(`/groups/${groupId}/albums/${album.id}/upload`);
+            }}
+          >
+            {/* 앨범 썸네일 컨테이너 */}
+            <div className="relative aspect-square rounded-[10px] overflow-hidden bg-gray-100">
+              {album.recentMedia.length > 0 ? (
+                <img
+                  src={album.recentMedia[0].fileUrl}
+                  alt={`${album.title} 썸네일`}
+                  className="w-full h-full object-cover"
+                />
+              ) : (
+                <div className="w-full h-full flex items-center justify-center bg-gradient-to-br from-gray-200 to-gray-300">
+                  <AiOutlineCamera className="size-12 text-gray-400" />
+                </div>
+              )}
+
+              {/* 호버 오버레이 */}
+              <div className="absolute inset-0 bg-black bg-opacity-60 opacity-0 group-hover:opacity-100 transition-opacity duration-200 flex flex-col items-center justify-center">
+                <HiOutlinePlus className="size-8 text-white mb-2" />
+                <span className="text-white font-medium">업로드 하기</span>
+              </div>
+            </div>
+
+            {/* 앨범 제목 */}
+            <h3 className="mt-2 text-center font-medium text-gray-700 truncate px-1 hover:underline">
+              {album.title}
+            </h3>
+            <p className="text-center text-sm text-gray-500 truncate">
+              {album.description}
+            </p>
+          </div>
+        ))}
+      </div>
+
+      {albums.length === 0 && (
+        <div className="text-center text-gray-500 mt-12">
+          <p>생성된 앨범이 없습니다.</p>
+          <p className="text-sm mt-1">먼저 앨범을 생성해주세요.</p>
+        </div>
+      )}
+    </>
+  );
+};

--- a/src/app/groups/[id]/albums/select/page.tsx
+++ b/src/app/groups/[id]/albums/select/page.tsx
@@ -1,16 +1,16 @@
 import { redirect } from 'next/navigation';
 
 import { getCurrentUser } from '@/features/actions';
-import { EditGroup } from './_components/edit-group';
 
 import { User as UserType } from '@/model/user';
+import { AlbumList } from './_components/album-list';
 
 type Props = {
   params: { id: string };
 };
 
 const Page = async ({ params }: Props) => {
-  const { id } = params;
+  const id = params.id;
 
   const user: UserType = await getCurrentUser();
 
@@ -20,7 +20,7 @@ const Page = async ({ params }: Props) => {
 
   return (
     <div className="w-full h-full sm:w-[500px] bg-[#FAFCFF] sm:mx-auto">
-      <EditGroup id={id} />
+      <AlbumList groupId={id} />
     </div>
   );
 };

--- a/src/app/groups/[id]/edit/_components/edit-group.tsx
+++ b/src/app/groups/[id]/edit/_components/edit-group.tsx
@@ -1,20 +1,19 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-
-import { Button } from '@/components/ui/button';
-
 import { FormProvider, useForm } from 'react-hook-form';
 import { useRouter } from 'next/navigation';
 import { useMutation, useQuery } from '@tanstack/react-query';
+import { FaArrowLeft } from 'react-icons/fa';
 
 import '@/app/signup/verifyInputStyle.css';
 
 import '@/components/embla/embla.css';
-import useEmblaCarousel from 'embla-carousel-react';
+import { Button } from '@/components/ui/button';
+import { PrevButton } from '@/components/embla/EmblaCarouselButtons';
 import { GroupInput } from '@/app/groups/_components/group-input';
+
 import { getGroupById } from '@/features/group/api/getGroupById';
-import { AiOutlineLoading3Quarters } from 'react-icons/ai';
 
 type FormInputs = {
   groupName: string;
@@ -28,7 +27,6 @@ type Props = {
 // TODO: 페이지 반응형
 export const EditGroup = ({ id }: Props) => {
   const router = useRouter();
-  const [emblaRef, emblaApi] = useEmblaCarousel({ watchDrag: false });
   const [preview, setPreview] = useState<{
     dataUrl: string;
     file: File;
@@ -133,8 +131,16 @@ export const EditGroup = ({ id }: Props) => {
 
   return (
     <main>
-      <article className="sm:mx-auto w-full sm:w-[500px] mx-auto">
-        <section ref={emblaRef} className="overflow-hidden h-full mb-[80px]">
+      <article>
+        <section className="overflow-hidden h-full">
+          <div>
+            <PrevButton
+              onClick={() => router.replace(`/groups/${id}/dashboard`)}
+              className="w-[34px] h-[34px] text-[34px]"
+            >
+              <FaArrowLeft className="w-[34px] h-[34px]" />
+            </PrevButton>
+          </div>
           <FormProvider {...form}>
             <form
               className="flex h-full"

--- a/src/app/groups/create/_components/create-group.tsx
+++ b/src/app/groups/create/_components/create-group.tsx
@@ -5,10 +5,7 @@ import useEmblaCarousel from 'embla-carousel-react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { useRouter } from 'next/navigation';
 import { useMutation } from '@tanstack/react-query';
-
-import LoginHeader from '@/components/LoginHeader';
 import { Button } from '@/components/ui/button';
-
 import Link from 'next/link';
 import { FaArrowLeft } from 'react-icons/fa6';
 
@@ -25,6 +22,8 @@ import {
 } from '@/components/embla/EmblaCarouselButtons';
 import { GroupInput } from '../../_components/group-input';
 
+import useUserStore from '@/store/useUserInfo';
+
 type FormInputs = {
   groupName: string;
   groupDescription: string;
@@ -33,6 +32,7 @@ type FormInputs = {
 
 export const CreateGroup = () => {
   const [emblaRef, emblaApi] = useEmblaCarousel({ watchDrag: false });
+  const setCurrentGroupId = useUserStore((state) => state.setCurrentGroupId);
   const [inviteCode, setInviteCode] = useState(null);
   const router = useRouter();
 
@@ -61,8 +61,8 @@ export const CreateGroup = () => {
       return response.json();
     },
     onSuccess: async (response) => {
-      console.log('초대코드:', response.data.inviteCode);
       alert('그룹이 생성되었습니다!');
+      setCurrentGroupId(Number(response.data.id));
       setInviteCode(response.data.inviteCode);
       onNextButtonClick();
     },
@@ -119,7 +119,16 @@ export const CreateGroup = () => {
 
   return (
     <main>
-      <LoginHeader></LoginHeader>
+      {selectedIndex === 0 && (
+        <div>
+          <PrevButton
+            onClick={() => router.replace('/profile')}
+            className="w-[34px] h-[34px] text-[34px]"
+          >
+            <FaArrowLeft className="w-[34px] h-[34px]" />
+          </PrevButton>
+        </div>
+      )}
       <div className="embla__dots mb-[25px]">
         {scrollSnaps.map((_, index) => (
           <DotButton
@@ -130,113 +139,95 @@ export const CreateGroup = () => {
           />
         ))}
       </div>
-      <article className="max-w-md mx-auto">
-        <section ref={emblaRef} className="overflow-hidden h-full">
-          <FormProvider {...form}>
-            <form
-              className="flex h-full"
-              onSubmit={form.handleSubmit(onSubmit)}
-            >
+      <section ref={emblaRef} className="overflow-hidden h-full">
+        <FormProvider {...form}>
+          <form className="flex h-full" onSubmit={form.handleSubmit(onSubmit)}>
+            <div className="min-w-full p-4 flex flex-col items-center" key={0}>
+              <h2 className="text-[28px] font-bold text-center mb-[27px]">
+                그룹을 <br></br> 만들어 봐요
+              </h2>
               <div
-                className="min-w-full p-4 flex flex-col items-center"
-                key={0}
+                onClick={handleClick}
+                className="cursor-pointer w-[177px] h-[177px] rounded-full border-4 border-[#4848F9] flex items-center justicy-center mb-[44px] overflow-hidden"
               >
-                <h2 className="text-[28px] font-bold text-center mb-[27px]">
-                  그룹을 <br></br> 만들어 봐요
-                </h2>
-                <div
-                  onClick={handleClick}
-                  className="cursor-pointer w-[177px] h-[177px] rounded-full border-4 border-[#4848F9] flex items-center justicy-center mb-[44px] overflow-hidden"
-                >
-                  {preview && (
-                    <img
-                      src={preview.dataUrl}
-                      className="block size-full object-cover"
-                    />
-                  )}
-                  <input
-                    ref={imageRef}
-                    accept="image/*"
-                    type="file"
-                    hidden
-                    onChange={handleImageUpload}
-                    className="w-[177px] h-[177px] rounded-full cursor-pointer"
-                    onClick={(e) => e.stopPropagation()}
+                {preview && (
+                  <img
+                    src={preview.dataUrl}
+                    className="block size-full object-cover"
                   />
-                </div>
-                <GroupInput
-                  name="groupName"
-                  label="그룹 이름"
-                  control={control}
-                  placeholder="그룹 이름을 입력해주세요"
-                  errorMessage="그룹 이름을 입력해주세요."
-                />
-                <GroupInput
-                  name="groupDescription"
-                  label="그룹 설명"
-                  control={control}
-                  placeholder="예) 가족 앨범, 자녀 앨범"
-                  errorMessage="그룹에 대한 설명을 입력해주세요."
-                />
-                {mutation.isPending ? (
-                  <Button type="button" disabled className="cursor-not-allowed">
-                    그룹 생성 중...
-                  </Button>
-                ) : (
-                  <Button
-                    type="submit"
-                    disabled={
-                      preview === null ||
-                      groupNameValue.length === 0 ||
-                      groupDescriptionValue.length === 0
-                    }
-                  >
-                    그룹 만들기
-                  </Button>
                 )}
+                <input
+                  ref={imageRef}
+                  accept="image/*"
+                  type="file"
+                  hidden
+                  onChange={handleImageUpload}
+                  className="w-[177px] h-[177px] rounded-full cursor-pointer"
+                  onClick={(e) => e.stopPropagation()}
+                />
               </div>
+              <GroupInput
+                name="groupName"
+                label="그룹 이름"
+                control={control}
+                placeholder="그룹 이름을 입력해주세요"
+                errorMessage="그룹 이름을 입력해주세요."
+              />
+              <GroupInput
+                name="groupDescription"
+                label="그룹 설명"
+                control={control}
+                placeholder="예) 가족 앨범, 자녀 앨범"
+                errorMessage="그룹에 대한 설명을 입력해주세요."
+              />
+              {mutation.isPending ? (
+                <Button type="button" disabled className="cursor-not-allowed">
+                  그룹 생성 중...
+                </Button>
+              ) : (
+                <Button
+                  type="submit"
+                  disabled={
+                    preview === null ||
+                    groupNameValue.length === 0 ||
+                    groupDescriptionValue.length === 0
+                  }
+                >
+                  그룹 만들기
+                </Button>
+              )}
+            </div>
 
-              {/* 초대코드 단계 */}
-              <div
-                className="min-w-full p-4 flex flex-col items-center mt-[100px]"
-                key={2}
-              >
-                <h2 className="text-[30px] font-bold mb-3 text-center">
-                  초대코드
-                </h2>
-                <p className="text-[16px] text-[#858585] mb-[14px]">
-                  앨범을 공유할 가족을 초대해보세요!
-                </p>
-                <p className="text-[64px] text-[#4848F9]">{inviteCode}</p>
-                <div className="fixed bottom-[6%]">
-                  <Button
-                    asChild
-                    className="mb-[33px] bg-[#FEE500] text-black hover:bg-[#FEE500]/80"
-                  >
-                    <Link href={'/'}>공유하기</Link>
-                  </Button>
-                  <Button type="button" onClick={() => router.replace('/home')}>
-                    시작하기
-                  </Button>
-                </div>
+            {/* 초대코드 단계 */}
+            <div
+              className="min-w-full p-4 flex flex-col items-center mt-[100px]"
+              key={2}
+            >
+              <h2 className="text-[30px] font-bold mb-3 text-center">
+                초대코드
+              </h2>
+              <p className="text-[16px] text-[#858585] mb-[14px]">
+                앨범을 공유할 가족을 초대해보세요!
+              </p>
+              <p className="text-[64px] text-[#4848F9]">{inviteCode}</p>
+              <div className="fixed bottom-[6%]">
+                <Button
+                  asChild
+                  className="mb-[33px] bg-[#FEE500] text-black hover:bg-[#FEE500]/80"
+                >
+                  <Link href={'/'}>공유하기</Link>
+                </Button>
+                <Button type="button" onClick={() => router.replace('/home')}>
+                  시작하기
+                </Button>
               </div>
-            </form>
-          </FormProvider>
-          {/* 
+            </div>
+          </form>
+        </FormProvider>
+        {/* 
           TODO: 초대코드 복사 기능
           */}
-          {selectedIndex === 0 && (
-            <div className="fixed top-[54px] left-[27px]">
-              <PrevButton
-                onClick={() => router.replace('/profile')}
-                className="w-[34px] h-[34px] text-[34px]"
-              >
-                <FaArrowLeft className="w-[34px] h-[34px]" />
-              </PrevButton>
-            </div>
-          )}
-        </section>
-      </article>
+      </section>
     </main>
   );
 };

--- a/src/app/groups/create/page.tsx
+++ b/src/app/groups/create/page.tsx
@@ -1,7 +1,11 @@
 import { CreateGroup } from './_components/create-group';
 
 const Page = () => {
-  return <CreateGroup />;
+  return (
+    <div className="w-full h-full sm:w-[500px] bg-[#FAFCFF] sm:mx-auto">
+      <CreateGroup />
+    </div>
+  );
 };
 
 export default Page;

--- a/src/app/groups/join/page.tsx
+++ b/src/app/groups/join/page.tsx
@@ -1,13 +1,14 @@
 'use client';
 
-import { FaArrowLeft } from 'react-icons/fa6';
-import { Button } from '@/components/ui/button';
-
-import VerificationInput from 'react-verification-input';
-import '@/app/signup/verifyInputStyle.css';
-import { useRouter } from 'next/navigation';
-import { useMutation } from '@tanstack/react-query';
 import { useState } from 'react';
+import { FaArrowLeft } from 'react-icons/fa6';
+import { useMutation } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+import VerificationInput from 'react-verification-input';
+
+import '@/app/signup/verifyInputStyle.css';
+import { Button } from '@/components/ui/button';
+import { PrevButton } from '@/components/embla/EmblaCarouselButtons';
 
 const join = () => {
   const router = useRouter();
@@ -55,7 +56,15 @@ const join = () => {
   };
 
   return (
-    <div className="sm:mx-auto w-full h-full sm:w-[500px]">
+    <div className="w-full h-full sm:w-[500px] bg-[#FAFCFF] sm:mx-auto">
+      <div>
+        <PrevButton
+          onClick={() => router.replace('/profile')}
+          className="w-[34px] h-[34px] text-[34px]"
+        >
+          <FaArrowLeft className="w-[34px] h-[34px]" />
+        </PrevButton>
+      </div>
       <div className="flex flex-col h-full justify-around">
         {/* 그룹참여 단계 */}
         <div className="p-4 flex flex-col items-center">
@@ -91,14 +100,6 @@ const join = () => {
             시작하기
           </Button>
         </div>
-      </div>
-      <div className="fixed top-[54px] left-[27px]">
-        <button
-          className="w-[34px] h-[34px] text-[34px]"
-          onClick={() => router.replace('/profile')}
-        >
-          <FaArrowLeft className="w-[34px] h-[34px]" />
-        </button>
       </div>
     </div>
   );

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -318,7 +318,7 @@ const home = () => {
               href={
                 hasAlbums
                   ? // ? `/groups/${groupId}/albums/${selectedAlbumId}/upload`
-                    `/groups/${groupId}/albums/1/upload`
+                    `/groups/${groupId}/albums/select`
                   : `/groups/${groupId}/albums`
               }
             >

--- a/src/components/Gnb.tsx
+++ b/src/components/Gnb.tsx
@@ -43,7 +43,6 @@ const Gnb = () => {
     '/signup',
     '/signup/join',
     '/signup/group/create',
-    '/groups/create',
     '/groups/join',
   ];
 
@@ -63,30 +62,99 @@ const Gnb = () => {
   const groupDashboardRegex = /^\/groups\/[^/]+\/dashboard$/;
   const groupMembersRegex = /^\/groups\/[^/]+\/members$/;
 
-  let currentPathName;
-  if (pathname.includes('albums')) {
-    currentPathName = '앨범';
-  } else if (pathname.includes('likes')) {
-    currentPathName = '좋아요';
-  } else if (pathname.includes('collection')) {
-    currentPathName = '컬렉션';
-  } else if (pathname === '/answers') {
-    currentPathName = '답변하기';
-  } else if (pathname === '/uploads/owners') {
-    currentPathName = '앨범 만들기';
-  } else if (pathname === '/uploads/members') {
-    currentPathName = '질문하기';
-  } else if (pathname.includes('profile')) {
-    currentPathName = '프로필';
-  } else if (pathname.includes('/questions')) {
-    currentPathName = '질문';
-  } else if (groupDashboardRegex.test(pathname)) {
-    currentPathName = '그룹 관리';
-  } else if (groupEditRegex.test(pathname)) {
-    currentPathName = '그룹 수정';
-  } else if (groupMembersRegex.test(pathname)) {
-    currentPathName = '내 그룹 멤버 보기';
-  }
+  const pathNameMap = {
+    '/albums': '앨범',
+    '/albums/[id]': '앨범',
+    '/groups/[id]/albums/[albumId]': '앨범',
+    '/groups/[id]/albums/[albumId]/photo/[mediaId]': '앨범',
+    '/likes': '좋아요',
+    '/collection': '컬렉션',
+    '/profile': '프로필',
+    '/profile/edit': '프로필 수정',
+    '/password-change': '비밀번호 변경',
+    '/groups/create': '그룹 생성',
+    '/groups/[id]/dashboard': '그룹 관리',
+    '/groups/[id]/edit': '그룹 수정',
+    '/groups/[id]/members': '내 그룹 멤버 보기',
+    '/groups/[id]/albums': '앨범',
+    '/groups/[id]/albums/select': '앨범 선택',
+    '/groups/[id]/albums/[albumId]/upload': '앨범 업로드',
+    '/groups/[id]/albums/[albumId]/answers': '답변하기',
+    '/groups/[id]/albums/[albumId]/answers/[mediaId]': '답변하기',
+  } as const;
+
+  // let currentPathName;
+  // if (pathname.includes('albums')) {
+  //   currentPathName = '앨범';
+  // } else if (pathname.includes('likes')) {
+  //   currentPathName = '좋아요';
+  // } else if (pathname.includes('collection')) {
+  //   currentPathName = '컬렉션';
+  // } else if (pathname === '/answers') {
+  //   currentPathName = '답변하기';
+  // } else if (pathname.includes('profile')) {
+  //   currentPathName = '프로필';
+  // } else if (pathname.includes('/questions')) {
+  //   currentPathName = '질문';
+  // } else if (groupDashboardRegex.test(pathname)) {
+  //   currentPathName = '그룹 관리';
+  // } else if (groupEditRegex.test(pathname)) {
+  //   currentPathName = '그룹 수정';
+  // } else if (groupMembersRegex.test(pathname)) {
+  //   currentPathName = '내 그룹 멤버 보기';
+  // }
+
+  type PathNames = keyof typeof pathNameMap;
+
+  const matchPath = (pathname: string): string => {
+    // 정확히 일치하는 경로 먼저 확인
+    if (pathname in pathNameMap) {
+      return pathNameMap[pathname as PathNames];
+    }
+
+    // 동적 경로 매칭
+    const patterns = [
+      { regex: /^\/albums\/[^\/]+$/, title: '앨범' },
+      {
+        regex: /^\/groups\/[^\/]+\/albums\/[^\/]+\/photo\/[^\/]+$/,
+        title: '앨범',
+      },
+      {
+        regex: /^\/groups\/[^\/]+\/albums\/[^\/]+$/,
+        title: '앨범',
+      },
+      { regex: /^\/groups\/[^\/]+\/dashboard$/, title: '그룹 관리' },
+      { regex: /^\/groups\/[^\/]+\/edit$/, title: '그룹 수정' },
+      { regex: /^\/groups\/[^\/]+\/members$/, title: '내 그룹 멤버 보기' },
+      { regex: /^\/groups\/[^\/]+\/albums\/select$/, title: '앨범 선택' },
+      {
+        regex: /^\/groups\/[^\/]+\/albums\/[^\/]+\/upload$/,
+        title: '앨범 업로드',
+      },
+      {
+        regex: /^\/groups\/[^\/]+\/albums\/[^\/]+\/answers$/,
+        title: '답변하기',
+      },
+      {
+        regex: /^\/groups\/[^\/]+\/albums\/[^\/]+\/answers\/[^\/]+$/,
+        title: '답변하기',
+      },
+      { regex: /^\/groups\/[^\/]+\/albums$/, title: '앨범' },
+    ];
+
+    for (const pattern of patterns) {
+      if (pattern.regex.test(pathname)) {
+        return pattern.title;
+      }
+    }
+
+    // 기본값
+    return '페이지';
+  };
+
+  // 사용
+  const currentPathName: string = matchPath(pathname);
+
   console.log(currentPathName);
 
   return (
@@ -148,7 +216,7 @@ const Gnb = () => {
                   </p>
                 </div>
                 </Link> */}
-                <Link href={`/groups/${groupId}/upload`}>
+                <Link href={`/groups/${groupId}/albums/select`}>
                   <div className="flex justify-center items-center flex-col">
                     <BubbleChatQuestionIcon color="#85B6FF" />
                     <p className="font-extrabold text-[6px] text-[#626262] mt-[5px]">
@@ -174,7 +242,7 @@ const Gnb = () => {
                   <div className="flex justify-center items-center flex-col">
                     <UserGroupIcon color="#85B6FF" />
                     <p className="font-extrabold text-[6px] text-[#626262] mt-[5px]">
-                      그룹 보기
+                      멤버 보기
                     </p>
                   </div>
                 </Link>

--- a/src/features/album/api/getAlbumsByGroupId.ts
+++ b/src/features/album/api/getAlbumsByGroupId.ts
@@ -1,0 +1,23 @@
+export async function getAlbumsByGroupId({
+  queryKey,
+}: {
+  queryKey: [string, string];
+}) {
+  const [_1, id] = queryKey;
+  const response = await fetch(
+    `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/v1/albums/group/${id}?thumbnailCount=1`,
+    {
+      next: {
+        tags: ['groupAlbums', id],
+      },
+      credentials: 'include',
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch group album data');
+  }
+
+  const { data } = await response.json();
+  return data;
+}


### PR DESCRIPTION
### 앨범 선택 페이지 추가 /groups/[id]/albums/select
- 그룹의 앨범을 선택 후 질문할 수 있음
- 홈페이지와 사이드바에 라우트 경로 연결 

### 그룹 생성 후 생성한 그룹의 홈으로 이동 
- currentGroupId를 생성한 그룹의 아이디로 변경, 바로 해당 그룹에 대한 홈으로 이동할 수 있게 수정

### css 정리
- 안쓰는 css 속성 지움, 페이지 별 레이아웃 통일
- 뒤로가기 버튼 추가 

### gnb header
- pathname을 기반으로 객체 매핑 방식으로 변경, 라우트 경로 추가 